### PR TITLE
support make -B flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ setup: clean submodules n64split split
 print-% : ; $(info $* is a $(flavor $*) variable set to [$($*)]) @true
 
 $(BUILD_DIR):
-	mkdir $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/$(TARGET).elf: $(O_FILES) $(LD_SCRIPT)
 	@$(LD) $(LDFLAGS) -o $@ $(O_FILES)


### PR DESCRIPTION
Tiny change to have `make -B` (force rebuild everything) not fail when `build` exists already.