### PR TITLE
add editor dotfiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yaml]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ bin/
 build/
 yay0/
 expected/
-.vscode/
 .idea/
 .DS_Store
 venv/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+    "version": 4,
+    "configurations": [
+        {
+            "name": "papermario",
+            "includePath": [
+                "${workspaceFolder}/include"
+            ],
+            "defines": [
+                "F3DEX_GBI_2",
+                "_LANGUAGE_C"
+            ],
+            "cStandard": "c89",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "gcc-x86"
+        }
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "nanaian.vscode-star-rod",
+	],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "files.eol": "\n",
+    "files.insertFinalNewline": true,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,81 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "make",
+            "type": "shell",
+            "command": "PM_HEADER_REBUILD=1 make all",
+            "problemMatcher": [
+                {
+                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "pattern": {
+                        "regexp": "^(src\\/.*):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "severity": 3,
+                        "message": 4,
+                    },
+                },
+                {
+                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "severity": "error",
+                    "pattern": {
+                        "regexp": "^(src\\/.*):(\\d+):\\s+(?!warning|\\()(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "message": 3,
+                    },
+                },
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true,
+            },
+        },
+        {
+            "label": "diff",
+            "type": "shell",
+            "command": "PM_HEADER_REBUILD=1 ./diff.py -mwo ${input:funcName}",
+            "isBackground": true,
+            "problemMatcher": [
+                {
+                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "background": {
+                        "activeOnStart": true,
+                    },
+                    "pattern": {
+                        "regexp": "^(src\\/.*):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "severity": 3,
+                        "message": 4,
+                    },
+                },
+                {
+                    "fileLocation": ["relative", "${workspaceFolder}"],
+                    "background": {
+                        "activeOnStart": true,
+                    },
+                    "severity": "error",
+                    "pattern": {
+                        "regexp": "^(src\\/.*):(\\d+):\\s+(?!warning|\\()(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "message": 3,
+                    },
+                },
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true,
+            },
+        },
+    ],
+    "inputs": [
+        {
+            "id": "funcName",
+            "description": "Function name",
+            "type": "promptString",
+        }
+    ],
+}


### PR DESCRIPTION
Added dotfiles for vscode and a generic `.editorconfig` for other editors that support it. AFAIK including complex editor-specific (but _not_ user-specific) configuration like this is pretty normal for repos.

On vscode, you can use ctrl+shift+b (run default build task) to compile the game, which reports errors and warnings from the compiler in-editor (see image). Additionally I made a test task for running `diff.py` - it prompts you for a function name before running.

![image](https://user-images.githubusercontent.com/9429556/90316849-ed356800-df1c-11ea-8221-1f0d089cee43.png)
