### PR TITLE
Fix GitHub's language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=C


### PR DESCRIPTION
GitHub current thinks some of the header files in this repo are written in Objective-C or C++:
![image](https://user-images.githubusercontent.com/9429556/90397710-2b9f6400-e090-11ea-977a-6ef9a2253a9c.png)

This minor PR [tells github/linguist that *.h files are written in C](https://github.com/github/linguist#overrides).

(FTR, [zeldaret/oot](https://github.com/zeldaret/oot) has the same issue - it might be worth doing something similar there too. It even has a `.gitattributes` file already!)