### PR TITLE
add dependencies for n64splat

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 # Ubuntu
-if command -v apt-install &> /dev/null; then
+if command -v apt-get &> /dev/null; then
     echo "Installing packages for Ubuntu"
 
-    sudo apt install -y git build-essential binutils-mips-linux-gnu zlib1g-dev libcapstone-dev libyaml-dev gcc-multilib || exit 1
+    sudo apt-get install -y git python3 python3-pip build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev gcc-multilib || exit 1
+    python3 -m pip install capstone
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
-        sudo apt install -y python3 python3-pip clang-tidy astyle || exit 1
+        sudo apt-get install -y clang-tidy astyle || exit 1
         python3 -m pip install stringcase || exit 1
     fi
 
@@ -24,7 +25,8 @@ if command -v pacman &> /dev/null; then
     sudo pacman -Syu || exit 1
 
     # Install dependencies
-    sudo pacman -S --noconfirm --needed git base-devel zlib capstone libyaml lib32-glibc || exit 1
+    sudo pacman -S --noconfirm --needed git python python-pip base-devel zlib libyaml lib32-glibc || exit 1
+    python3 -m pip install capstone
 
     # Install binutils if required
     if ! command -v mips-linux-gnu-ar &> /dev/null; then
@@ -48,7 +50,7 @@ if command -v pacman &> /dev/null; then
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
-        sudo pacman -S --noconfirm --needed python python-pip clang astyle || exit 1
+        sudo pacman -S --noconfirm --needed clang astyle || exit 1
         python3 -m pip install stringcase || exit 1
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # Ubuntu
-if command -v apt-get &> /dev/null; then
+if command -v apt &> /dev/null; then
     echo "Installing packages for Ubuntu"
 
-    sudo apt-get install -y git python3 python3-pip build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev gcc-multilib || exit 1
+    sudo apt install -y git python3 python3-pip build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev gcc-multilib || exit 1
     python3 -m pip install capstone
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
-        sudo apt-get install -y clang-tidy astyle || exit 1
+        sudo apt install -y clang-tidy astyle || exit 1
         python3 -m pip install stringcase || exit 1
     fi
 


### PR DESCRIPTION
Might also be good to add a `requirements.txt` to n64splat's repo and install that.
The change from `apt install` to `apt-get install` should support WSL's Ubuntu better.