### PR TITLE
readme: remove mips_to_c branch-likely workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Decide on a function to match. These can be found in the subdirectories of `asm/
 
 Take the relevant `.s` file and pass it to [mips_to_c](https://github.com/matt-kempster/mips_to_c) ([web version](https://simonsoftware.se/other/mips_to_c.py)).
 
-If mips_to_c gives you an error about branch-likely instructions, edit the `.s` file and rename any branch-likely instructions to their unlikely equivalent (i.e. remove the `l` suffix). Add a `nop` after the branches and move the instruction that was originally in the delay slot (directly after the branch instruction) to the start of the target label. Don't commit the edited assembly.
-
 Open up the relevant `.c` file and replace the function's `INCLUDE_ASM` macro with the output from mips_to_c. Run the following command to attempt to compile, replacing `function_name` with the name of the function you're working with:
 
 ```sh


### PR DESCRIPTION
As discussed before this workaround is _bad_ and results in incorrect control flow output. I believe I saw @ethteck saying that mips_to_c has rudimentary support for likely branches now anyway.