### PR TITLE
move windows_terminal.bat instructions to 'Contributing' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Discord: [Paper Mario Modding](https://discord.gg/urUm3VG)
 
 ## Setup
 
-You'll need Linux, a Linux VM, or Windows 10 (WSL) to work on this project. For WSL, we've included `windows_termainl.bat` under tools that you can use to quickly spin up a terminal for your default distro set using `wsl --set-default <Distro>`.
+You'll need Linux, a Linux VM, or [Windows 10 (WSL2)](#wsl) to work on this project.
 
 #### Clone the repository
-
 ```sh
 $ git clone https://github.com/ethteck/papermario.git
 $ cd papermario
@@ -48,6 +47,10 @@ If you get `OK`, you're all set! Otherwise, please feel free to reach out to us 
 ### Dependencies
 
 There are a few additional dependencies needed when contributing to this project. You can install them with `./install.sh --extra`.
+
+### WSL
+
+We provide [windows_terminal.bat](tools/windows_terminal.bat) to open a [Windows Terminal](https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701) with a recommended layout. Make sure a default distro (e.g. `wsl --set-default ubuntu`) is set beforehand.
 
 ### Rebuilding
 

--- a/tools/windows_terminal.bat
+++ b/tools/windows_terminal.bat
@@ -1,3 +1,2 @@
 REM first set your default distro using: wsl --set-default <Distro>
-ehco "first set your default distro using: wsl --set-default <Distro>"
 wt --title "diff.py" -d "../" ; split-pane -d "../" -V ; new-tab --title "mips_to_c.py" -d "../" ; focus-tab -t 0


### PR DESCRIPTION
Also fixed a number of typos in the process.

(FTR, I somewhat question the existence of this file at all - it appears to include a tab for mips_to_c.py despite it isn't necessarily installed on the local machine. I recall @ethteck mentioning we will eventually include mips_to_c under tools/, which negates this issue.)