### PR TITLE
Update install.sh to include the dependencies of diff.py for --extra

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,12 @@ if command -v apt &> /dev/null; then
     echo "Installing packages for Ubuntu"
 
     sudo apt install -y git python3 python3-pip build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev gcc-multilib || exit 1
-    python3 -m pip install capstone
+    python3 -m pip install -U -r requirements.txt
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
         sudo apt install -y clang-tidy astyle || exit 1
-        python3 -m pip install stringcase || exit 1
+        python3 -m pip install -U -r requirements_extra.txt || exit 1
     fi
 
     echo "Done"
@@ -26,7 +26,7 @@ if command -v pacman &> /dev/null; then
 
     # Install dependencies
     sudo pacman -S --noconfirm --needed git python python-pip base-devel zlib libyaml lib32-glibc || exit 1
-    python3 -m pip install capstone
+    python3 -m pip install -U -r requirements.txt
 
     # Install binutils if required
     if ! command -v mips-linux-gnu-ar &> /dev/null; then
@@ -51,7 +51,7 @@ if command -v pacman &> /dev/null; then
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
         sudo pacman -S --noconfirm --needed clang astyle || exit 1
-        python3 -m pip install stringcase || exit 1
+        python3 -m pip install -U -r requirements_extra.txt || exit 1
     fi
 
     echo "Done"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+capstone

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 capstone
+pycparser
+PyYAML

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,0 +1,6 @@
+ansiwrap
+colorama
+cxxfilt
+python-Levenshtein
+stringcase
+watchdog


### PR DESCRIPTION
`install.sh` doesn't install certain dependencies like `colorama`, even though it does install other ones:
https://github.com/Gorialis/papermario/blob/1f54aaefa1605837375e8f91ef792294b88a18a1/install.sh#L8
https://github.com/Gorialis/papermario/blob/1f54aaefa1605837375e8f91ef792294b88a18a1/install.sh#L13

However, `colorama` and others are required by `diff.py` and it will fail without them:
https://github.com/Gorialis/papermario/blob/1f54aaefa1605837375e8f91ef792294b88a18a1/diff.py#L218-L228

This adjusts install.sh so `install.sh --extra` will install the extra `diff.py` dependencies.
This also pulls the dependencies out of `install.sh` into their own `requirements.txt` and `requirements_extra.txt` so separate distros will not have to maintain their own Python dependencies in the future.