### PR TITLE
Updates to compiler/lint warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,20 @@
-Checks: '-*,clang-analyzer-core.*,clang-analyzer-deadcode.*,readability-*,-readability-magic-numbers,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-readability-function-size,-readability-non-const-parameter'
-HeaderFilterRegex: '(src|include)\/.*\.h'
+Checks: '-*,clang-analyzer-core.*,clang-analyzer-deadcode.*,readability-*,-readability-magic-numbers,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-readability-function-size,-readability-non-const-parameter,readability-identifier-naming'
+CheckOptions:
+  - key: readability-identifier-naming.LocalVariableCase
+    value: camelBack
+  - key: readability-identifier-naming.ParameterCase
+    value: camelBack
+
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+
+  # TODO: rename all unk_XXX members
+  #- key: readability-identifier-naming.MemberCase
+  #  value: camelBack
+
+  # TODO: rename all D_XXXXXXXX symbols
+  #- key: readability-identifier-naming.GlobalVariableCase
+  #  value: CamelCase
+  #- key: readability-identifier-naming.GlobalVariablePrefix
+  #  value: g
+HeaderFilterRegex: '(src|include)\/[^P].*\.h' # ignore inclue/PR/

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ TARGET = papermario
 CPPFLAGS   = -Iinclude -Isrc -D _LANGUAGE_C -ffreestanding -DF3DEX_GBI_2
 ASFLAGS    = -EB -Iinclude -march=vr4300 -mtune=vr4300
 OLDASFLAGS = -EB -Iinclude -G 0
-CFLAGS     = -O2 -quiet -G 0 -mcpu=vr4300 -mfix4300 -mips3 -mgp32 -mfp32
+CFLAGS     = -O2 -quiet -G 0 -mcpu=vr4300 -mfix4300 -mips3 -mgp32 -mfp32 -Wimplicit -Wuninitialized -Wshadow
 LDFLAGS    = -T undefined_syms.txt -T undefined_funcs.txt -T $(LD_SCRIPT) -Map $(BUILD_DIR)/papermario.map --no-check-sections
 
 ######################## Targets #############################

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ all: $(TARGET).ld $(BUILD_DIR) $(TARGET).z64 verify
 clean:
 	rm -rf $(BUILD_DIR) $(TARGET).z64
 
+clean-code:
+	rm -rf $(BUILD_DIR)/src $(TARGET).z64
+
 submodules:
 	git submodule update --init --recursive
 

--- a/include/macros.h
+++ b/include/macros.h
@@ -15,6 +15,7 @@
 
 #define ASSERT(condition) if (!(condition)) { while (1) {} }
 #define PANIC() ASSERT(0)
+#define STATIC_ASSERT(condition) enum { static_assert_fail = 1/(!!(condition)) } // Causes division by zero ("not integer constant") if false
 
 #define GAME_STATUS (*gGameStatusPtr)
 #define PLAYER_STATUS (&gPlayerStatus)

--- a/include/script_api/common.h
+++ b/include/script_api/common.h
@@ -4,7 +4,7 @@
 #include "common_structs.h"
 #include "si.h"
 
-typedef Bytecode Script[];
+typedef Bytecode Script[0];
 
 ApiStatus FadeBackgroundToBlack(ScriptInstance* script, s32 isInitialCall);
 ApiStatus UnfadeBackgroundFromBlack(ScriptInstance* script, s32 isInitialCall);


### PR DESCRIPTION
Note `-Wimplicit` shouts about a _lot_ of implicitly-declared functions right now, but that can be fixed with time