### PR TITLE
install python-setuptools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 if command -v apt &> /dev/null; then
     echo "Installing packages for Ubuntu (apt)"
 
-    sudo apt install -y git python3 python3-pip build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev || exit 1
+    sudo apt install -y git python3 python3-pip python3-setuptools build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev || exit 1
     python3 -m pip install -U -r requirements.txt
 
     if [[ $1 == "--extra" ]]; then
@@ -25,7 +25,7 @@ if command -v pacman &> /dev/null; then
     sudo pacman -Syu || exit 1
 
     # Install dependencies
-    sudo pacman -S --noconfirm --needed git python python-pip base-devel zlib libyaml || exit 1
+    sudo pacman -S --noconfirm --needed git python python-pip python-setuptools base-devel zlib libyaml || exit 1
     python3 -m pip install -U -r requirements.txt
 
     # Install binutils if required
@@ -62,7 +62,7 @@ fi
 if command -v zypper &> /dev/null; then
     echo "Installing packages for openSUSE (zypper)"
 
-    sudo zypper -n install git python3 python3-devel python3-pip gcc gcc-c++ glibc-devel make cross-mips-binutils zlib-devel libyaml-devel
+    sudo zypper -n install git python3 python3-devel python3-pip python3-setuptools gcc gcc-c++ glibc-devel make cross-mips-binutils zlib-devel libyaml-devel
 
     # Link the openSUSE locations for binutils tools to their usual GNU locations
     sudo ln -s /usr/bin/mips-suse-linux-addr2line /usr/bin/mips-linux-gnu-addr2line


### PR DESCRIPTION
This was a requirement of PyYAML that happens to be installed on most systems already, hence why we didn't catch it