### PR TITLE
remove local variable case camelBack requirement

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,9 @@
 Checks: '-*,clang-analyzer-core.*,clang-analyzer-deadcode.*,readability-*,-readability-magic-numbers,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-isolate-declaration,-readability-uppercase-literal-suffix,-readability-function-size,-readability-non-const-parameter,readability-identifier-naming'
 CheckOptions:
-  - key: readability-identifier-naming.LocalVariableCase
-    value: camelBack
+  # TEMP: this only disabled because mips2c outputs snake_case
+  #- key: readability-identifier-naming.LocalVariableCase
+  #  value: camelBack
+
   - key: readability-identifier-naming.ParameterCase
     value: camelBack
 


### PR DESCRIPTION
As discussed with @ethteck, I'm disabling this warning because mips_to_c outputs identifiers like `temp_v0` by default, and seeing the warnings during early function decompilation is unhelpful and annoying (plus we'd likely pick up issues like these in code review).

(are we even sure we want to use camelCase for parameters/struct fields? personally I think I'd prefer snake_case for everything but types... worth discussing this I think)